### PR TITLE
Add Windows Server 2022 Dockerfile and update CUDA

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - name: setup
       run: |
-        choco install cuda -y
+        choco install cuda --version=12.2 -y
     - name: configure
       run: |
         $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,14 +10,14 @@ stages:
 before_script:
  - choco install cmake -y
  - $env:PATH="C:\Program Files\CMake\bin;$env:PATH"
- - curl.exe -L http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_441.22_win10.exe --output cuda_installer.exe
+ - curl.exe -L https://developer.download.nvidia.com/compute/cuda/12.2.0/local_installers/cuda_12.2.0_windows.exe --output cuda_installer.exe
  - 7z x cuda_installer.exe -o"cuda_installer"
- - Start-Process -FilePath ".\cuda_installer\setup.exe" -ArgumentList "-s nvcc_10.2 cublas_10.2 cublas_dev_10.2 cudart_10.2 curand_10.2 curand_dev_10.2 cusolver_10.2 cusolver_dev_10.2 cusparse_10.2 cusparse_dev_10.2" -Wait -NoNewWindow
+ - Start-Process -FilePath ".\cuda_installer\setup.exe" -ArgumentList "-s nvcc_12.2 cublas_12.2 cublas_dev_12.2 cudart_12.2 curand_12.2 curand_dev_12.2 cusolver_12.2 cusolver_dev_12.2 cusparse_12.2 cusparse_dev_12.2" -Wait -NoNewWindow
  - echo $?
  - copy "cuda_installer\CUDAVisualStudioIntegration\extras\visual_studio_integration\MSBuildExtensions\*.*" "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VC\v160\BuildCustomizations"
- - $env:PATH="$env:ProgramFiles\NVIDIA GPU Computing Toolkit\CUDA\v10.2\bin;$env:PATH"
- - $env:CUDA_PATH="$env:ProgramFiles\NVIDIA GPU Computing Toolkit\CUDA\v10.2"
- - $env:CUDA_PATH_V10_2="$env:ProgramFiles\NVIDIA GPU Computing Toolkit\CUDA\v10.2"
+ - $env:PATH="$env:ProgramFiles\NVIDIA GPU Computing Toolkit\CUDA\v12.2\bin;$env:PATH"
+ - $env:CUDA_PATH="$env:ProgramFiles\NVIDIA GPU Computing Toolkit\CUDA\v12.2"
+ - $env:CUDA_PATH_V12_2="$env:ProgramFiles\NVIDIA GPU Computing Toolkit\CUDA\v12.2"
  - Remove-Item –path cuda_installer –recurse 
  - Remove-Item cuda_installer.exe
  

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo creates the dockerfiles for using cuda in windows docker and provides 
 The docker images are availble in the docker hub https://hub.docker.com/repository/docker/yhmtsai/windows_cuda
 
 Pull images:
-`docker pull yhmtsai/windows_cuda:windows_1903` or `docker pull yhmtsai/windows_cuda:windows_server_ltsc2019`
+`docker pull yhmtsai/windows_cuda:windows_1903` or `docker pull yhmtsai/windows_cuda:windows_server_ltsc2019` or `docker pull yhmtsai/windows_cuda:windows_server_ltsc2022`
 
 Run powershell:
 `docker run -it --rm yhmtsai/windows_cuda:tag powershell`
@@ -23,7 +23,7 @@ They should work for different windows/cuda version. Changing the MSVC version (
 ## Windows
 Windows containers only needs `choco install cuda` and copy the MSVC related files to the corresponding path.
 ## Windows Server
-According to the [documentation](https://docs.microsoft.com/en-us/visualstudio/install/build-tools-container?view=vs-2019), use mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019 not mcr.microsoft.com/windows/servercore:ltsc2019 as base image. Otherwise, installing MSVC requires reboot to lead the failure.
+According to the [documentation](https://docs.microsoft.com/en-us/visualstudio/install/build-tools-container?view=vs-2019), use mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022 not mcr.microsoft.com/windows/servercore:ltsc2022 as base image. Otherwise, installing MSVC requires reboot to lead the failure.
 
 Note. using `"` in dockerfile of windows server gives some error.
 ### CUDA
@@ -67,9 +67,9 @@ The following is run in `cmd`. Runing it in powershell needs to another way to i
 
 using server version needs the following setting. (I try several ways to update PATH but all leads the failure. Thus, need to set environment of cuda first)
 ```
-set PATH=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.2\bin;%PATH%
-set CUDA_PATH=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.2
-set CUDA_PATH_V10_2=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.2
+set PATH=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v12.2\bin;%PATH%
+set CUDA_PATH=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v12.2
+set CUDA_PATH_V12_2=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v12.2
 ```
 
 The test:
@@ -89,18 +89,18 @@ Note. the ctest gets error because we do not have cuda device inside the contain
 # NOTE: find the corresponding path of MSVC integration
 `choco install cuda` install integration into the path mentioned in the cuda documentation. However, it seems to work on MSVC IDE not MSVC buildtools. (I do not find the proper way to install MSVC IDE with `vcvars64.bat` environment. I only found using MSVC buildtools to compile project)
 
-In my experience, if the cmake reports `CUDA Toolkit Not Found`, use `cmake -T cuda=10.2` toolchain setting may give the hint of the path.
+In my experience, if the cmake reports `CUDA Toolkit Not Found`, use `cmake -T cuda=12.2` toolchain setting may give the hint of the path.
 
-Delete the last line of windows_1903.dockerfile, and try to use `cmake -T cuda=10.2 -DCMAKE_CUDA_COMPILER="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.2/bin/nvcc.exe" -DGINKGO_BUILD_CUDA=ON -DGINKGO_BUILD_OMP=OFF ..` (cmake can not find CUDA_COMPILER when set -T, so needs `-DCMAKE_CUDA_COMPILER=...`) on Ginkgo Project.
+Delete the last line of windows_1903.dockerfile, and try to use `cmake -T cuda=12.2 -DCMAKE_CUDA_COMPILER="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.2/bin/nvcc.exe" -DGINKGO_BUILD_CUDA=ON -DGINKGO_BUILD_OMP=OFF ..` (cmake can not find CUDA_COMPILER when set -T, so needs `-DCMAKE_CUDA_COMPILER=...`) on Ginkgo Project.
 
 The error message:
 ```
 error MSB4019:
-The imported project "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VC\v160\BuildCustomizations\CUDA 10.2.props" was not found.
-Confirm that the expression in the Import declaration "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VC\v160\\BuildCustomizations\CUDA 10.2.props" is correct, and that the file exists on disk.
+The imported project "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VC\v160\BuildCustomizations\CUDA 12.2.props" was not found.
+Confirm that the expression in the Import declaration "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VC\v160\\BuildCustomizations\CUDA 12.2.props" is correct, and that the file exists on disk.
 ```
 
-cmake tries to finds `CUDA 10.2.props` in `C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VC\v160\BuildCustomizations`
+cmake tries to finds `CUDA 12.2.props` in `C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VC\v160\BuildCustomizations`
 
 Thus, we need to copy integration in `C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\BuildCustomizations\*.*` in original correct path or `cuda\CUDAVisualStudioIntegration\extras\visual_studio_integration\MSBuildExtensions\*.*` the extraction of local installer to the corresponding path `C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VC\v160\BuildCustomizations`
 

--- a/windows_1903.dockerfile
+++ b/windows_1903.dockerfile
@@ -8,5 +8,5 @@ RUN choco install cmake -y --installargs '"ADD_CMAKE_TO_PATH=System"'
 RUN choco install visualstudio2019buildtools --package-parameters "--includeRecommended --includeOptional" -y
 RUN choco install visualstudio2019-workload-vctools -y
 
-RUN choco install cuda -y
+RUN choco install cuda --version=12.2 -y
 RUN copy "C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\BuildCustomizations\*.*" "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VC\v160\BuildCustomizations"

--- a/windows_server_ltsc2022.dockerfile
+++ b/windows_server_ltsc2022.dockerfile
@@ -1,6 +1,6 @@
-# FROM mcr.microsoft.com/windows/servercore:ltsc2019
+# FROM mcr.microsoft.com/windows/servercore:ltsc2022
 # Reference https://docs.microsoft.com/en-us/visualstudio/install/build-tools-container?view=vs-2019
-FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022
 
 RUN Set-ExecutionPolicy AllSigned
 RUN Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))


### PR DESCRIPTION
## Summary
- add a Dockerfile for Windows Server 2022
- update existing Dockerfiles to CUDA 12.2
- update CI scripts to use CUDA 12.2
- document new image and CUDA version

## Testing
- `pytest -q`