### PR TITLE
Add PowerShell script to build 2022 Docker image

### DIFF
--- a/build-docker-win2022.ps1
+++ b/build-docker-win2022.ps1
@@ -1,0 +1,6 @@
+# Build the Windows Server 2022 CUDA Docker image
+
+# Invoke docker build using the Windows Server 2022 dockerfile.
+# The resulting image is tagged with `windows_server_ltsc2022`.
+
+docker build -m 2GB -f windows_server_ltsc2022.dockerfile -t windows_server_ltsc2022 .


### PR DESCRIPTION
## Summary
- add `build-docker-win2022.ps1` to easily build the Windows Server 2022 CUDA image

## Testing
- `true`