### PR TITLE
Add nvidia-smi test script for Windows 2022

### DIFF
--- a/docker-test-win2022-nvsmi.ps1
+++ b/docker-test-win2022-nvsmi.ps1
@@ -1,0 +1,7 @@
+# Build and test the Windows Server 2022 CUDA Docker image
+
+# Build the Docker image from the Windows Server 2022 dockerfile.
+docker build -m 2GB -f windows_server_ltsc2022.dockerfile -t windows_server_ltsc2022 .
+
+# Run the image interactively and execute nvidia-smi to verify CUDA installation.
+docker run -it --rm windows_server_ltsc2022 powershell -Command "nvidia-smi"


### PR DESCRIPTION
## Summary
- add script to build Windows Server 2022 image and run `nvidia-smi`

## Testing
- `shellcheck docker-test-win2022-nvsmi.ps1` *(fails: command not found)*