### PR TITLE
Fix Set-ExecutionPolicy on Windows Server 2022

### DIFF
--- a/windows_server_ltsc2022.dockerfile
+++ b/windows_server_ltsc2022.dockerfile
@@ -1,6 +1,7 @@
 # FROM mcr.microsoft.com/windows/servercore:ltsc2022
 # Reference https://docs.microsoft.com/en-us/visualstudio/install/build-tools-container?view=vs-2019
 FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022
+SHELL ["powershell", "-Command"]
 
 RUN Set-ExecutionPolicy AllSigned
 RUN Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))


### PR DESCRIPTION
## Summary
- ensure commands run under PowerShell in `windows_server_ltsc2022.dockerfile`

## Testing
- `git status --short`